### PR TITLE
Move minimum ESPHome version requirement into validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ ESPHome component to monitor and control a Sportstech Treadmill F15 via BLE
 
 ## Requirements
 
-* [ESPHome 2024.6.0 or higher](https://github.com/esphome/esphome/releases).
+* [ESPHome 2026.1.0 or higher](https://github.com/esphome/esphome/releases).
 * Generic ESP32 board
 
 ## Installation

--- a/components/treadmill_f15/__init__.py
+++ b/components/treadmill_f15/__init__.py
@@ -29,7 +29,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)
-    .extend(cv.polling_component_schema("10s"))
+    .extend(cv.polling_component_schema("10s")),
 )
 
 

--- a/components/treadmill_f15/__init__.py
+++ b/components/treadmill_f15/__init__.py
@@ -21,7 +21,8 @@ TREADMILL_F15_COMPONENT_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2026, 1, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(TreadmillF15),

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -9,7 +9,6 @@ esphome:
   name: ${name}
   comment: ${device_description}
   friendly_name: ${friendly_name}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-treadmill-f15"
     version: 1.2.0

--- a/esp32-ble-scanner.yaml
+++ b/esp32-ble-scanner.yaml
@@ -5,7 +5,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2026.1.0
   project:
     name: "syssi.esphome-treadmill-f15"
     version: 1.2.0

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -6,7 +6,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.6.0
 
 esp32:
   board: esp32-c6-devkitc-1


### PR DESCRIPTION
Removes min_version from all YAML configurations and enforces the version constraint via cv.require_esphome_version() in the component validator instead.