### PR TITLE
Remove redundant .extend(cv.COMPONENT_SCHEMA) from switch and button schemas

### DIFF
--- a/components/treadmill_f15/button/__init__.py
+++ b/components/treadmill_f15/button/__init__.py
@@ -33,12 +33,8 @@ TreadmillButton = treadmill_f15_ns.class_(
 
 CONFIG_SCHEMA = TREADMILL_F15_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_START): button.button_schema(
-            TreadmillButton, icon=ICON_START
-        ),
-        cv.Optional(CONF_STOP): button.button_schema(
-            TreadmillButton, icon=ICON_STOP
-        ),
+        cv.Optional(CONF_START): button.button_schema(TreadmillButton, icon=ICON_START),
+        cv.Optional(CONF_STOP): button.button_schema(TreadmillButton, icon=ICON_STOP),
     }
 )
 

--- a/components/treadmill_f15/button/__init__.py
+++ b/components/treadmill_f15/button/__init__.py
@@ -35,10 +35,10 @@ CONFIG_SCHEMA = TREADMILL_F15_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_START): button.button_schema(
             TreadmillButton, icon=ICON_START
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_STOP): button.button_schema(
             TreadmillButton, icon=ICON_STOP
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 


### PR DESCRIPTION
## Summary
- Remove `.extend(cv.COMPONENT_SCHEMA)` from all `switch.switch_schema()` and `button.button_schema()` calls
- `switch_schema()` and `button_schema()` include the component schema internally since ESPHome ~2023 — the explicit `.extend()` is redundant