### PR TITLE
Add entity_category to binary sensor and switch schemas

### DIFF
--- a/components/treadmill_f15/binary_sensor.py
+++ b/components/treadmill_f15/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_TREADMILL_F15_ID, TREADMILL_F15_COMPONENT_SCHEMA
 
@@ -24,13 +24,21 @@ BINARY_SENSORS = [
 CONFIG_SCHEMA = TREADMILL_F15_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_STARTING): binary_sensor.binary_sensor_schema(
-            icon="mdi:rocket-launch"
+            icon="mdi:rocket-launch",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_RUNNING): binary_sensor.binary_sensor_schema(
-            icon="mdi:run-fast"
+            icon="mdi:run-fast",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
-        cv.Optional(CONF_STOPPING): binary_sensor.binary_sensor_schema(icon="mdi:run"),
-        cv.Optional(CONF_STOPPED): binary_sensor.binary_sensor_schema(icon="mdi:pause"),
+        cv.Optional(CONF_STOPPING): binary_sensor.binary_sensor_schema(
+            icon="mdi:run",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_STOPPED): binary_sensor.binary_sensor_schema(
+            icon="mdi:pause",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
     }
 )
 
@@ -40,6 +48,5 @@ async def to_code(config):
     for key in BINARY_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            await binary_sensor.register_binary_sensor(sens, conf)
+            sens = await binary_sensor.new_binary_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_binary_sensor")(sens))

--- a/components/treadmill_f15/button/__init__.py
+++ b/components/treadmill_f15/button/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import button
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_STOP
+from esphome.const import CONF_STOP
 
 from .. import CONF_TREADMILL_F15_ID, TREADMILL_F15_COMPONENT_SCHEMA, treadmill_f15_ns
 
@@ -44,9 +44,8 @@ async def to_code(config):
     for button_type in BUTTON_TYPES:
         if button_type in config:
             conf = config[button_type]
-            var = cg.new_Pvariable(conf[CONF_ID])
+            var = await button.new_button(conf)
             await cg.register_component(var, conf)
-            await button.register_button(var, conf)
             cg.add(var.set_parent(hub))
             cg.add(var.set_button_type(button_type))
 

--- a/components/treadmill_f15/number/__init__.py
+++ b/components/treadmill_f15/number/__init__.py
@@ -2,7 +2,6 @@ import esphome.codegen as cg
 from esphome.components import number
 import esphome.config_validation as cv
 from esphome.const import (
-    CONF_ID,
     CONF_INITIAL_VALUE,
     CONF_MAX_VALUE,
     CONF_MIN_VALUE,
@@ -105,15 +104,13 @@ async def to_code(config):
     for key, number_config in NUMBERS.items():
         if key in config:
             conf = config[key]
-            var = cg.new_Pvariable(conf[CONF_ID])
-            await cg.register_component(var, conf)
-            await number.register_number(
-                var,
+            var = await number.new_number(
                 conf,
                 min_value=conf[CONF_MIN_VALUE],
                 max_value=conf[CONF_MAX_VALUE],
                 step=conf[CONF_STEP],
             )
+            await cg.register_component(var, conf)
             cg.add(var.set_parent(hub))
             cg.add(var.set_command_type(key))
             cg.add(var.set_holding_register(number_config))


### PR DESCRIPTION
Add entity_category=ENTITY_CATEGORY_DIAGNOSTIC to all binary sensors (they report hardware state and protection events). Add entity_category=ENTITY_CATEGORY_CONFIG to configuration switches (bluetooth, buzzer, display). Primary functional switches (charging, discharging, balancer) remain uncategorized. This improves the Home Assistant entity list organization.