### PR TITLE
Fix product name in log messages

### DIFF
--- a/components/treadmill_f15/treadmill_f15.cpp
+++ b/components/treadmill_f15/treadmill_f15.cpp
@@ -56,7 +56,7 @@ void TreadmillF15::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t
       auto *char_notify =
           this->parent_->get_characteristic(TREADMILL_BMS_SERVICE_UUID, TREADMILL_BMS_NOTIFY_CHARACTERISTIC_UUID);
       if (char_notify == nullptr) {
-        ESP_LOGE(TAG, "[%s] No notify service found at device, not an Treadmill BMS..?",
+        ESP_LOGE(TAG, "[%s] No notify service found at device, not a Treadmill F15..?",
                  ADDR_STR(this->parent_->address_str()));
         break;
       }
@@ -90,7 +90,7 @@ void TreadmillF15::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t
       auto *char_command =
           this->parent_->get_characteristic(TREADMILL_BMS_SERVICE_UUID, TREADMILL_BMS_CONTROL_CHARACTERISTIC_UUID);
       if (char_command == nullptr) {
-        ESP_LOGE(TAG, "[%s] No control service found at device, not an Treadmill BMS..?",
+        ESP_LOGE(TAG, "[%s] No control service found at device, not a Treadmill F15..?",
                  ADDR_STR(this->parent_->address_str()));
         break;
       }


### PR DESCRIPTION
## Summary

- Both error log messages for missing notify and control service said `not an Treadmill BMS..?` — copy-paste artifacts referencing a BMS instead of the actual device.
- Corrected to `not a Treadmill F15..?`.