### PR TITLE
Iterate over BINARY_SENSOR_DEFS/SENSOR_DEFS directly in to_code

### DIFF
--- a/components/treadmill_f15/binary_sensor.py
+++ b/components/treadmill_f15/binary_sensor.py
@@ -34,8 +34,6 @@ BINARY_SENSOR_DEFS = {
     },
 }
 
-BINARY_SENSORS = list(BINARY_SENSOR_DEFS)
-
 CONFIG_SCHEMA = TREADMILL_F15_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(key): binary_sensor.binary_sensor_schema(**kwargs)
@@ -46,7 +44,7 @@ CONFIG_SCHEMA = TREADMILL_F15_COMPONENT_SCHEMA.extend(
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_TREADMILL_F15_ID])
-    for key in BINARY_SENSORS:
+    for key in BINARY_SENSOR_DEFS:
         if key in config:
             conf = config[key]
             sens = await binary_sensor.new_binary_sensor(conf)

--- a/components/treadmill_f15/sensor.py
+++ b/components/treadmill_f15/sensor.py
@@ -78,8 +78,6 @@ SENSOR_DEFS = {
     },
 }
 
-SENSORS = list(SENSOR_DEFS)
-
 CONFIG_SCHEMA = TREADMILL_F15_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(key): sensor.sensor_schema(**kwargs)
@@ -90,7 +88,7 @@ CONFIG_SCHEMA = TREADMILL_F15_COMPONENT_SCHEMA.extend(
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_TREADMILL_F15_ID])
-    for key in SENSORS:
+    for key in SENSOR_DEFS:
         if key in config:
             conf = config[key]
             sens = await sensor.new_sensor(conf)


### PR DESCRIPTION
## Summary

- Remove redundant `BINARY_SENSORS = list(BINARY_SENSOR_DEFS)` and `SENSORS = list(SENSOR_DEFS)` aliases
- Iterate over `BINARY_SENSOR_DEFS` / `SENSOR_DEFS` directly in `to_code` instead