### PR TITLE
Fix BLE scanner UUID API for ESPHome 2026.4.0

### DIFF
--- a/esp32-ble-scanner.yaml
+++ b/esp32-ble-scanner.yaml
@@ -40,9 +40,9 @@ esp32_ble_tracker:
             ESP_LOGI("ble_adv", "  Name: %s", x.get_name().c_str());
             ESP_LOGI("ble_adv", "  MAC address: %s", x.address_str().c_str());
             ESP_LOGD("ble_adv", "  Advertised service UUIDs:");
+            char uuidstr[esphome::esp32_ble::UUID_STR_LEN];
             for (auto uuid : x.get_service_uuids()) {
-              char buf[ESPBTUUID::UUID_STR_LEN];
-              ESP_LOGD("ble_adv", "    - %s", uuid.to_str(buf));
+              ESP_LOGD("ble_adv", "    - %s", uuid.to_str(uuidstr));
             }
           }
 

--- a/esp32-ble-scanner.yaml
+++ b/esp32-ble-scanner.yaml
@@ -5,6 +5,7 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
+  min_version: "2026.1.0"
   project:
     name: "syssi.esphome-treadmill-f15"
     version: 1.2.0


### PR DESCRIPTION
Fix BLE scanner UUID API compatibility with ESPHome 2026.4.0

 was removed in ESPHome 2026.4.0. Replace with  and move the buffer declaration outside the loop.

Reported in: https://github.com/syssi/esphome-jk-bms/issues/936