### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/treadmill_f15/button/treadmill_button.cpp
+++ b/components/treadmill_f15/button/treadmill_button.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace treadmill_f15 {
+namespace esphome::treadmill_f15 {
 
 static const char *const TAG = "treadmill_f15.button";
 
@@ -36,5 +35,4 @@ void TreadmillButton::press_action() {
   }
 }
 
-}  // namespace treadmill_f15
-}  // namespace esphome
+}  // namespace esphome::treadmill_f15

--- a/components/treadmill_f15/button/treadmill_button.h
+++ b/components/treadmill_f15/button/treadmill_button.h
@@ -5,8 +5,7 @@
 #include "esphome/components/button/button.h"
 #include <vector>
 
-namespace esphome {
-namespace treadmill_f15 {
+namespace esphome::treadmill_f15 {
 
 class TreadmillF15;
 
@@ -28,5 +27,4 @@ class TreadmillButton : public button::Button, public Component {
   std::vector<uint8_t> command_payload_;
 };
 
-}  // namespace treadmill_f15
-}  // namespace esphome
+}  // namespace esphome::treadmill_f15

--- a/components/treadmill_f15/number/treadmill_number.cpp
+++ b/components/treadmill_f15/number/treadmill_number.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace treadmill_f15 {
+namespace esphome::treadmill_f15 {
 
 static const char *const TAG = "treadmill_f15.number";
 
@@ -36,5 +35,4 @@ void TreadmillNumber::control(float value) {
   }
 }
 
-}  // namespace treadmill_f15
-}  // namespace esphome
+}  // namespace esphome::treadmill_f15

--- a/components/treadmill_f15/number/treadmill_number.h
+++ b/components/treadmill_f15/number/treadmill_number.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/number/number.h"
 
-namespace esphome {
-namespace treadmill_f15 {
+namespace esphome::treadmill_f15 {
 
 class TreadmillF15;
 
@@ -28,5 +27,4 @@ class TreadmillNumber : public number::Number, public Component {
   float initial_value_;
 };
 
-}  // namespace treadmill_f15
-}  // namespace esphome
+}  // namespace esphome::treadmill_f15

--- a/components/treadmill_f15/treadmill_f15.cpp
+++ b/components/treadmill_f15/treadmill_f15.cpp
@@ -9,8 +9,7 @@
 #define ADDR_STR(x) (x).c_str()
 #endif
 
-namespace esphome {
-namespace treadmill_f15 {
+namespace esphome::treadmill_f15 {
 
 static const char *const TAG = "treadmill_f15";
 
@@ -365,5 +364,4 @@ bool TreadmillF15::send_speed_incline_command(float speed, float incline) {
   return send_raw_command(command);
 }
 
-}  // namespace treadmill_f15
-}  // namespace esphome
+}  // namespace esphome::treadmill_f15

--- a/components/treadmill_f15/treadmill_f15.h
+++ b/components/treadmill_f15/treadmill_f15.h
@@ -12,8 +12,7 @@
 
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace treadmill_f15 {
+namespace esphome::treadmill_f15 {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -118,7 +117,6 @@ class TreadmillF15 : public esphome::ble_client::BLEClientNode, public PollingCo
   }
 };
 
-}  // namespace treadmill_f15
-}  // namespace esphome
+}  // namespace esphome::treadmill_f15
 
 #endif


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` clang-tidy check is active in ESPHome's `.clang-tidy` (no longer disabled). All nested `namespace esphome { namespace treadmill_f15 {` blocks are replaced with `namespace esphome::treadmill_f15 {`.