### PR TITLE
Fix format specifiers for data.size() in ESP_LOG calls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,10 +50,12 @@ jobs:
           ref: dev
           path: esphome
 
-      - name: Copy external component into the esphome project
+      - name: Copy external component and tests into the esphome project
         run: |
           cd esphome
           cp -r ../components/* esphome/components/
+          mkdir -p tests/components
+          cp -r ../tests/components/* tests/components/
           git config user.name "ci"
           git config user.email "ci@github.com"
           git add .

--- a/components/treadmill_f15/button/treadmill_button.cpp
+++ b/components/treadmill_f15/button/treadmill_button.cpp
@@ -10,7 +10,7 @@ void TreadmillButton::dump_config() {
   ESP_LOGCONFIG(TAG, "TreadmillF15 Button");
   ESP_LOGCONFIG(TAG, "  Button Type: %s", this->button_type_.c_str());
   ESP_LOGCONFIG(TAG, "  Register: 0x%02X", this->register_address_);
-  ESP_LOGCONFIG(TAG, "  Payload Length: %d bytes", this->command_payload_.size());
+  ESP_LOGCONFIG(TAG, "  Payload Length: %zu bytes", this->command_payload_.size());
   LOG_BUTTON("", "TreadmillF15 Button", this);
 }
 

--- a/components/treadmill_f15/treadmill_f15.cpp
+++ b/components/treadmill_f15/treadmill_f15.cpp
@@ -154,7 +154,7 @@ void TreadmillF15::decode_status_data_(const std::vector<uint8_t> &data) {
   ESP_LOGD(TAG, "  %s", format_hex_pretty_to(hex_buf, data.data(), data.size(), ' '));
 
   if (data.size() < 5) {
-    ESP_LOGW(TAG, "Invalid status frame length: %d", data.size());
+    ESP_LOGW(TAG, "Invalid status frame length: %zu", data.size());
     return;
   }
 
@@ -321,7 +321,7 @@ bool TreadmillF15::send_command(uint8_t register_addr, const std::vector<uint8_t
   command.push_back(0x03);
 
   char hex_buf[format_hex_pretty_size(MAX_RESPONSE_SIZE)];
-  ESP_LOGD(TAG, "Send structured command (register 0x%02X, payload %d bytes): %s", register_addr, payload.size(),
+  ESP_LOGD(TAG, "Send structured command (register 0x%02X, payload %zu bytes): %s", register_addr, payload.size(),
            format_hex_pretty_to(hex_buf, command.data(), command.size(), ' '));
 
   return send_raw_command(command);


### PR DESCRIPTION
Replace %d with %zu for size_t arguments in ESP_LOG calls to fix format specifier warnings.