### PR TITLE
Move BLE MAC address to secrets.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -493,7 +493,7 @@ jobs:
       - name: Validate example configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\ntreadmill0_mac_address: 70:3e:97:07:c0:3e" > secrets.yaml
           for YAML in esp*.yaml; do
             esphome -s external_components_source components config $YAML
           done
@@ -501,7 +501,7 @@ jobs:
       - name: Validate test configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > tests/secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\ntreadmill0_mac_address: 70:3e:97:07:c0:3e" > tests/secrets.yaml
           for YAML in tests/esp*.yaml; do
             esphome -s external_components_source ../components config $YAML
           done
@@ -544,7 +544,7 @@ jobs:
       - name: Compile example configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\ntreadmill0_mac_address: 70:3e:97:07:c0:3e" > secrets.yaml
           for YAML in esp*faker.yaml; do
             esphome -s external_components_source components compile $YAML
           done
@@ -554,7 +554,7 @@ jobs:
       - name: Compile test configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > tests/secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\ntreadmill0_mac_address: 70:3e:97:07:c0:3e" > tests/secrets.yaml
           esphome -s external_components_source ../components compile tests/esp32c6-compatibility-test.yaml
         env:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ wifi_password: MY_WIFI_PASSWORD
 mqtt_host: MY_MQTT_HOST
 mqtt_username: MY_MQTT_USERNAME
 mqtt_password: MY_MQTT_PASSWORD
+
+# Required for the BLE example only. Use the MAC address of your treadmill.
+treadmill0_mac_address: MY_TREADMILL_MAC_ADDRESS
 EOF
 
 # Validate the configuration, create a binary, upload it, and start logs

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -3,8 +3,6 @@ substitutions:
   friendly_name: treadmill-f15
   device_description: "Monitor a Sportstech Treadmill F15 via BLE"
   external_components_source: github://syssi/esphome-treadmill-f15@main
-  mac_address: 27:25:E1:46:CE:E4
-
 esphome:
   name: ${name}
   comment: ${device_description}
@@ -54,7 +52,7 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: ${mac_address}
+  - mac_address: !secret treadmill0_mac_address
     id: client0
 
 treadmill_f15:

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -36,7 +36,7 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: c8:47:8c:e8:82:09
+  - mac_address: !secret treadmill0_mac_address
     id: client0
 
 treadmill_f15:


### PR DESCRIPTION
## Summary

- Reference the BLE client MAC address via `!secret treadmill0_mac_address` directly in `ble_client:` instead of using a hard-coded YAML substitution
- Update CI to generate the required secret key (`treadmill0_mac_address`) with an example value
- Document the new secret in the README installation section